### PR TITLE
Fix LP producing parallel instead of orthogonal mCCAs 

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -12,5 +12,6 @@
         "REditorSupport.r"
       ]
     }
-  }
+  },
+  "postCreateCommand": "pip install -e ."
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,5 @@ COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /tmp/environment.yml
 RUN micromamba install -y -n base -f /tmp/environment.yml && \
     micromamba clean --all --yes
 
-# Install black & sparsecca
 RUN source /usr/local/bin/_activate_current_env.sh && \
-    pip install black && \
-    pip install .
+    pip install black

--- a/examples/linear_programming_multicca.ipynb
+++ b/examples/linear_programming_multicca.ipynb
@@ -42,51 +42,57 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[ 1.16289006, -1.10155538, -0.07361009, -1.04768133, -0.23030313],\n",
-       "       [-0.28524699, -0.95404835,  1.25754511,  2.22141375, -0.64806753],\n",
-       "       [-0.80371799, -0.09921252, -1.30902827, -0.12490934, -0.53780387],\n",
-       "       [ 1.23123296,  1.30839663,  2.35443782,  1.2004608 , -0.24753196],\n",
-       "       [ 1.24686808,  0.2176884 , -0.51074504,  1.68211628, -0.0589116 ],\n",
-       "       [-0.54485555, -0.31221068, -0.72426958,  0.11262969,  0.06324836],\n",
-       "       [-1.36002346, -2.02609761, -0.77052108, -1.47716523, -0.98507913],\n",
-       "       [ 2.01516562, -0.35919419,  0.98862972, -0.30120967, -1.85093266],\n",
-       "       [-1.43260253, -0.00428044, -0.31457342,  0.72451216,  0.59311224],\n",
-       "       [-0.46268311,  2.11013054, -0.80026669,  0.03718434, -0.66038343],\n",
-       "       [ 1.79330705, -1.77072566,  0.59342351,  0.5705045 , -0.26306724],\n",
-       "       [-0.53183765,  0.46836312, -0.16679474,  0.24751673,  0.48850261],\n",
-       "       [ 0.64762214, -0.2314719 , -0.00601488, -1.31931633, -0.02510419],\n",
-       "       [-0.0595952 , -1.14180706,  0.10746787, -0.35318886, -0.07661414],\n",
-       "       [-0.57148704,  0.79014662, -0.18573718,  1.04355359,  1.57775996],\n",
-       "       [ 1.29146116,  0.02004213,  0.69239577,  2.35286   , -1.56292662],\n",
-       "       [ 1.62873882, -1.23221121,  1.65388461, -0.3126268 , -0.7598255 ],\n",
-       "       [-1.62725948,  0.59066322,  0.97152531, -1.20732746, -0.8981499 ],\n",
-       "       [-1.32635761,  0.49787141, -1.41803712,  1.21642253, -0.06228299],\n",
-       "       [-0.82386691,  2.90123106,  0.50903272,  0.90469804, -0.51054396],\n",
-       "       [-0.51186988, -0.90623346, -0.09036516, -0.21023619,  0.17084248],\n",
-       "       [-0.57207486,  0.42464088,  0.51752789, -0.8194987 ,  3.15266947],\n",
-       "       [ 1.05896183,  1.39600636,  0.86299409,  0.79002278, -0.59867327],\n",
-       "       [-1.90949454,  0.09847346, -0.92126405,  0.53865328,  2.028253  ],\n",
-       "       [-0.83438946, -0.36229773, -1.29525538,  2.04590215,  1.0633799 ]])"
+       "(25, 5)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "inpt3"
+    "assert inpt1.shape[0] == inpt2.shape[0] == inpt3.shape[0]\n",
+    "inpt1.shape"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[-90.17027552,  11.82731312,  -7.86532209,  17.62955376,\n",
+       "        -17.56197152],\n",
+       "       [ 51.8255256 ,   6.41554333, -14.01087688, -46.99815802,\n",
+       "         16.29765355],\n",
+       "       [ 74.04185358,  29.92014574, -26.72555091, -42.34996728,\n",
+       "         26.97207374],\n",
+       "       [-47.72640718, -18.39841178, -21.55303292,  37.29813179,\n",
+       "        -27.72045331],\n",
+       "       [ -6.14657028,  18.29437855,   4.43004474,  -2.18546732,\n",
+       "         12.80321423]])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(inpt1.T @ inpt2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,32 +107,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[[-0.08911592,  0.05447262, -0.17954319],\n",
-       "        [ 0.66470561, -0.54663329,  0.6135666 ],\n",
-       "        [ 0.60794117, -0.65622806,  0.55246482],\n",
-       "        [-0.42496254,  0.42511018, -0.52736503],\n",
-       "        [-0.0062595 , -0.29473863, -0.08926939]],\n",
-       "\n",
-       "       [[ 0.49615515, -0.43360575,  0.50388569],\n",
-       "        [ 0.30569572, -0.57468281,  0.2926027 ],\n",
-       "        [-0.13754639, -0.06168402, -0.09398377],\n",
-       "        [-0.73325299,  0.47846533, -0.74173363],\n",
-       "        [ 0.32218201, -0.49899073,  0.31856108]]])"
+       "array([[ 1.        , -0.83859139],\n",
+       "       [-0.83859139,  1.        ]])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "weights"
+    "# pearson correlation of weights[0] and weights[1]\n",
+    "np.corrcoef(weights[0].flatten(), weights[1].flatten())\n"
    ]
   },
   {
@@ -138,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,15 +166,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=0.9746794344808964, pvalue=0.004818230468198537)\n",
-      "SignificanceResult(statistic=0.8999999999999998, pvalue=0.03738607346849874)\n"
+      "SignificanceResult(statistic=-0.9746794344808964, pvalue=0.004818230468198537)\n",
+      "SignificanceResult(statistic=0.09999999999999999, pvalue=0.8728885715695383)\n"
      ]
     }
    ],
@@ -194,15 +192,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=0.9746794344808964, pvalue=0.004818230468198537)\n",
-      "SignificanceResult(statistic=0.8999999999999998, pvalue=0.03738607346849874)\n"
+      "SignificanceResult(statistic=-0.9746794344808964, pvalue=0.004818230468198537)\n",
+      "SignificanceResult(statistic=0.09999999999999999, pvalue=0.8728885715695383)\n"
      ]
     }
    ],
@@ -227,27 +225,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
     "datasets = [inpt1, inpt2, inpt3]\n",
-    "ws_lp, _ = lp_pmd(datasets, penalties[:3])\n",
-    "ws_r, _ = multicca_pmd(datasets, penalties[:3])"
+    "ws_lp, _ = lp_pmd(datasets, penalties)\n",
+    "ws_r, _ = multicca_pmd(datasets, penalties)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=-0.8720815992723809, pvalue=0.05385421772754211)\n",
-      "SignificanceResult(statistic=-0.35909242322980395, pvalue=0.5528147466433505)\n",
-      "SignificanceResult(statistic=-0.09999999999999999, pvalue=0.8728885715695383)\n"
+      "SignificanceResult(statistic=-0.8207826816681233, pvalue=0.08858700531354381)\n",
+      "SignificanceResult(statistic=-0.09999999999999999, pvalue=0.8728885715695383)\n",
+      "SignificanceResult(statistic=-0.8207826816681233, pvalue=0.08858700531354381)\n"
      ]
     }
    ],
@@ -273,17 +271,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1st pair: [[111.69927657]]\n",
-      "2nd pair: [[16.09054608]]\n",
-      "3rd pair: [[29.41034686]]\n",
-      "sum [[157.20016951]]\n"
+      "1st pair: [[2.36359908e-06]]\n",
+      "2nd pair: [[5.40590458e-07]]\n",
+      "3rd pair: [[51.33244746]]\n",
+      "sum [[51.33245036]]\n"
      ]
     }
    ],
@@ -296,17 +294,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1st pair: [[108.09846793]]\n",
-      "2nd pair: [[21.92976799]]\n",
-      "3rd pair: [[30.2407647]]\n",
-      "sum [[160.26900062]]\n"
+      "1st pair: [[99.11315683]]\n",
+      "2nd pair: [[41.60492912]]\n",
+      "3rd pair: [[31.5520592]]\n",
+      "sum [[172.27014515]]\n"
      ]
     }
    ],
@@ -326,16 +324,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.7320508160371626"
+       "1.4142135829891374"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -346,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "metadata": {
     "scrolled": true
    },
@@ -357,7 +355,7 @@
        "1.7320508075688772"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -382,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,8 +401,8 @@
     "        boolean: True if rounded weights are the same, else False\n",
     "    \"\"\"\n",
     "    \n",
-    "    weights_a_rounded = weights_a.round(decimals=dec)\n",
-    "    weights_b_rounded = weights_b.round(decimals=dec)\n",
+    "    weights_a_rounded = np.array(weights_a).round(decimals=dec)\n",
+    "    weights_b_rounded = np.array(weights_b).round(decimals=dec)\n",
     "    \n",
     "    weights_b_ordered = []\n",
     "    for o in perm_b:\n",
@@ -415,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,44 +431,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "ws_lp, _ = lp_pmd(datasets, penalties)\n",
-    "ws_lp_perm, _ = lp_pmd(datasets_perm, penalties)"
+    "threshold = 1e-10\n",
+    "\n",
+    "ws_lp, _ = lp_pmd(datasets, [0.4, 0.0, 0.4])\n",
+    "ws_lp = np.array(ws_lp)\n",
+    "ws_lp[np.isclose(ws_lp, 0, rtol=threshold)] = 0\n",
+    "\n",
+    "ws_lp_perm, _ = lp_pmd(datasets_perm, [0.4, 0.0, 0.4])\n",
+    "ws_lp_perm = np.array(ws_lp_perm)\n",
+    "ws_lp_perm[np.isclose(ws_lp, 0, rtol=threshold)] = 0"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[[-0.06329702],\n",
-       "        [-0.47883099],\n",
-       "        [-0.71653621],\n",
-       "        [ 0.50235555],\n",
-       "        [-0.03048172]],\n",
+       "array([[[-6.09416697e-01],\n",
+       "        [-7.92850123e-01],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00]],\n",
        "\n",
-       "       [[-0.35167889],\n",
-       "        [-0.48543111],\n",
-       "        [-0.07157119],\n",
-       "        [ 0.54892933],\n",
-       "        [-0.57812867]],\n",
+       "       [[ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 8.88854528e-08],\n",
+       "        [ 0.00000000e+00]],\n",
        "\n",
-       "       [[-0.74880871],\n",
-       "        [-0.52826939],\n",
-       "        [-0.39417701],\n",
-       "        [ 0.00182197],\n",
-       "        [ 0.06955682]]])"
+       "       [[ 8.69830201e-01],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [-4.93351244e-01],\n",
+       "        [ 0.00000000e+00]]])"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -481,32 +486,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[[-0.74880871],\n",
-       "        [-0.52826939],\n",
-       "        [-0.39417701],\n",
-       "        [ 0.00182197],\n",
-       "        [ 0.06955682]],\n",
+       "array([[[-5.73418393e-18],\n",
+       "        [-1.01421456e-17],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00]],\n",
        "\n",
-       "       [[-0.06329702],\n",
-       "        [-0.47883099],\n",
-       "        [-0.71653621],\n",
-       "        [ 0.50235555],\n",
-       "        [-0.03048172]],\n",
+       "       [[ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 3.46602125e-11],\n",
+       "        [ 0.00000000e+00]],\n",
        "\n",
-       "       [[-0.35167889],\n",
-       "        [-0.48543111],\n",
-       "        [-0.07157119],\n",
-       "        [ 0.54892933],\n",
-       "        [-0.57812867]]])"
+       "       [[ 8.62126560e-01],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [ 0.00000000e+00],\n",
+       "        [-5.06693026e-01],\n",
+       "        [ 0.00000000e+00]]])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -517,16 +522,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "True"
+       "False"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -551,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,30 +566,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[array([[-0.        ],\n",
-       "        [ 0.8315665 ],\n",
-       "        [ 0.54048778],\n",
-       "        [-0.12794572],\n",
-       "        [-0.        ]]),\n",
-       " array([[ 0.72935664],\n",
-       "        [-0.0928381 ],\n",
-       "        [-0.        ],\n",
-       "        [-0.67780527],\n",
+       "[array([[ 0.        ],\n",
+       "        [ 0.90824506],\n",
+       "        [ 0.29728456],\n",
+       "        [-0.29447039],\n",
        "        [ 0.        ]]),\n",
-       " array([[ 0.        ],\n",
-       "        [ 0.89010769],\n",
-       "        [-0.42640703],\n",
-       "        [-0.15901786],\n",
-       "        [ 0.02446747]])]"
+       " array([[ 0.56055407],\n",
+       "        [-0.07202121],\n",
+       "        [ 0.04359745],\n",
+       "        [-0.82382725],\n",
+       "        [ 0.        ]]),\n",
+       " array([[-0.7682389 ],\n",
+       "        [-0.09935492],\n",
+       "        [-0.63240619],\n",
+       "        [ 0.        ],\n",
+       "        [-0.        ]])]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -595,30 +600,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[array([[ 0.12178605],\n",
-       "        [ 0.93963595],\n",
-       "        [-0.27441203],\n",
-       "        [-0.16416603],\n",
-       "        [ 0.        ]]),\n",
-       " array([[-0.        ],\n",
-       "        [ 0.75371432],\n",
-       "        [ 0.65012982],\n",
-       "        [-0.09615587],\n",
+       "[array([[-0.76824118],\n",
+       "        [-0.09935549],\n",
+       "        [-0.63240334],\n",
+       "        [ 0.        ],\n",
        "        [-0.        ]]),\n",
-       " array([[ 0.73184218],\n",
-       "        [-0.        ],\n",
-       "        [-0.        ],\n",
-       "        [-0.67508905],\n",
-       "        [ 0.09306875]])]"
+       " array([[ 0.        ],\n",
+       "        [ 0.90824509],\n",
+       "        [ 0.29727909],\n",
+       "        [-0.29447581],\n",
+       "        [ 0.        ]]),\n",
+       " array([[ 0.5605532 ],\n",
+       "        [-0.0720213 ],\n",
+       "        [ 0.04359766],\n",
+       "        [-0.82382782],\n",
+       "        [ 0.        ]])]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -636,7 +641,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IO sparsity: 0.4\n",
+      "LP sparsity: 0.6\n",
+      "IO sparsity: 0.19999999999999996\n",
+      "LP sparsity: 0.8\n",
+      "IO sparsity: 0.4\n",
+      "LP sparsity: 0.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "for i in range(len(ws_r)):\n",
+    "    print(\"IO penalties:\", 1 - np.count_nonzero(ws_r[i]) / ws_r[i].size)\n",
+    "    print(\"LP penalties:\", 1 - np.count_nonzero(ws_lp[i]) / ws_lp[i].size)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -645,7 +674,7 @@
        "False"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -663,16 +692,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -690,7 +719,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -699,7 +728,7 @@
        "False"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -718,9 +747,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:sparsecca]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-sparsecca-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -732,12 +761,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.0"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "d4d1e4263499bec80672ea0156c357c1ee493ec2b1c70f0acce89fc37c4a6abe"
-   }
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/examples/linear_programming_multicca.ipynb
+++ b/examples/linear_programming_multicca.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,57 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(25, 5)"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "assert inpt1.shape[0] == inpt2.shape[0] == inpt3.shape[0]\n",
-    "inpt1.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[-90.17027552,  11.82731312,  -7.86532209,  17.62955376,\n",
-       "        -17.56197152],\n",
-       "       [ 51.8255256 ,   6.41554333, -14.01087688, -46.99815802,\n",
-       "         16.29765355],\n",
-       "       [ 74.04185358,  29.92014574, -26.72555091, -42.34996728,\n",
-       "         26.97207374],\n",
-       "       [-47.72640718, -18.39841178, -21.55303292,  37.29813179,\n",
-       "        -27.72045331],\n",
-       "       [ -6.14657028,  18.29437855,   4.43004474,  -2.18546732,\n",
-       "         12.80321423]])"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "(inpt1.T @ inpt2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,37 +56,16 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[ 1.        , -0.83859139],\n",
-       "       [-0.83859139,  1.        ]])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# pearson correlation of weights[0] and weights[1]\n",
-    "np.corrcoef(weights[0].flatten(), weights[1].flatten())\n"
-   ]
-  },
-  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Correlation between pmd results and lp results"
+    "## Correlation between IO results and LP results"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,32 +84,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
     "datasets = [inpt1, inpt2]\n",
     "ws_lp, _ = lp_pmd(datasets, penalties[:2])\n",
-    "ws_r, _ = multicca_pmd(datasets, penalties[:2])"
+    "ws_io, _ = multicca_pmd(datasets, penalties[:2])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=-0.9746794344808964, pvalue=0.004818230468198537)\n",
-      "SignificanceResult(statistic=0.09999999999999999, pvalue=0.8728885715695383)\n"
+      "SignificanceResult(statistic=0.9746794344808964, pvalue=0.004818230468198537)\n",
+      "SignificanceResult(statistic=0.8999999999999998, pvalue=0.03738607346849874)\n"
      ]
     }
    ],
    "source": [
-    "print(spearmanr(ws_lp[0], ws_r[0]))\n",
-    "print(spearmanr(ws_lp[1], ws_r[1]))"
+    "print(spearmanr(ws_lp[0], ws_io[0]))\n",
+    "print(spearmanr(ws_lp[1], ws_io[1]))"
    ]
   },
   {
@@ -192,21 +121,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=-0.9746794344808964, pvalue=0.004818230468198537)\n",
-      "SignificanceResult(statistic=0.09999999999999999, pvalue=0.8728885715695383)\n"
+      "SignificanceResult(statistic=0.9746794344808964, pvalue=0.004818230468198537)\n",
+      "SignificanceResult(statistic=0.8999999999999998, pvalue=0.03738607346849874)\n"
      ]
     }
    ],
    "source": [
-    "print(spearmanr(weights[0].T[0], ws_r[0]))\n",
-    "print(spearmanr(weights[1].T[0], ws_r[1]))"
+    "print(spearmanr(weights[0].T[0], ws_io[0]))\n",
+    "print(spearmanr(weights[1].T[0], ws_io[1]))"
    ]
   },
   {
@@ -225,34 +154,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
     "datasets = [inpt1, inpt2, inpt3]\n",
     "ws_lp, _ = lp_pmd(datasets, penalties)\n",
-    "ws_r, _ = multicca_pmd(datasets, penalties)"
+    "ws_io, _ = multicca_pmd(datasets, penalties)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SignificanceResult(statistic=-0.8207826816681233, pvalue=0.08858700531354381)\n",
-      "SignificanceResult(statistic=-0.09999999999999999, pvalue=0.8728885715695383)\n",
-      "SignificanceResult(statistic=-0.8207826816681233, pvalue=0.08858700531354381)\n"
+      "SignificanceResult(statistic=0.20519567041703082, pvalue=0.7405819415910722)\n",
+      "SignificanceResult(statistic=-0.8999999999999998, pvalue=0.03738607346849874)\n",
+      "SignificanceResult(statistic=0.09999999999999999, pvalue=0.8728885715695383)\n"
      ]
     }
    ],
    "source": [
-    "print(spearmanr(ws_lp[0], ws_r[0]))\n",
-    "print(spearmanr(ws_lp[1], ws_r[1]))\n",
-    "print(spearmanr(ws_lp[2], ws_r[2]))"
+    "print(spearmanr(ws_lp[0], ws_io[0]))\n",
+    "print(spearmanr(ws_lp[1], ws_io[1]))\n",
+    "print(spearmanr(ws_lp[2], ws_io[2]))"
    ]
   },
   {
@@ -271,17 +200,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1st pair: [[2.36359908e-06]]\n",
-      "2nd pair: [[5.40590458e-07]]\n",
-      "3rd pair: [[51.33244746]]\n",
-      "sum [[51.33245036]]\n"
+      "1st pair: [[119.0135171]]\n",
+      "2nd pair: [[34.50213156]]\n",
+      "3rd pair: [[30.66377104]]\n",
+      "sum [[184.1794197]]\n"
      ]
     }
    ],
@@ -294,46 +223,54 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1st pair: [[99.11315683]]\n",
-      "2nd pair: [[41.60492912]]\n",
-      "3rd pair: [[31.5520592]]\n",
-      "sum [[172.27014515]]\n"
+      "1st pair: [[56.9713026]]\n",
+      "2nd pair: [[18.63386997]]\n",
+      "3rd pair: [[29.98425782]]\n",
+      "sum [[105.58943039]]\n"
      ]
     }
    ],
    "source": [
-    "print('1st pair:', ws_r[0].T @ inpt1.T @ inpt2 @ ws_r[1])\n",
-    "print('2nd pair:', ws_r[1].T @ inpt2.T @ inpt3 @ ws_r[2])\n",
-    "print('3rd pair:', ws_r[2].T @ inpt3.T @ inpt1 @ ws_r[0])\n",
-    "print('sum', ws_r[0].T @ inpt1.T @ inpt2 @ ws_r[1] + ws_r[1].T @ inpt2.T @ inpt3 @ ws_r[2] + ws_r[2].T @ inpt3.T @ inpt1 @ ws_r[0])"
+    "print('1st pair:', ws_io[0].T @ inpt1.T @ inpt2 @ ws_io[1])\n",
+    "print('2nd pair:', ws_io[1].T @ inpt2.T @ inpt3 @ ws_io[2])\n",
+    "print('3rd pair:', ws_io[2].T @ inpt3.T @ inpt1 @ ws_io[0])\n",
+    "print('sum', ws_io[0].T @ inpt1.T @ inpt2 @ ws_io[1] + ws_io[1].T @ inpt2.T @ inpt3 @ ws_io[2] + ws_io[2].T @ inpt3.T @ inpt1 @ ws_io[0])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "L2 norm of the latent factors, constrained."
+    "Neither linear programming nor manual convergence consistently produces a better optimization of the objective function in this small test case."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "L2 norm of the latent factors."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1.4142135829891374"
+       "1.73205081608457"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -344,7 +281,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 46,
    "metadata": {
     "scrolled": true
    },
@@ -355,20 +292,13 @@
        "1.7320508075688772"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "np.linalg.norm(ws_r)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Neither linear programming nor manual convergence consistently produces a better optimization of the objective function in this small test case."
+    "np.linalg.norm(ws_io)"
    ]
   },
   {
@@ -380,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,125 +343,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
     "datasets = [inpt1, inpt2, inpt3]\n",
-    "# original dataset with perm 1, 2, 0\n",
+    "# original dataset with permutation 1, 2, 0\n",
     "datasets_perm = [inpt3, inpt1, inpt2]"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### linear programming"
+    "### Linear Programming"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 49,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "threshold = 1e-10\n",
-    "\n",
     "ws_lp, _ = lp_pmd(datasets, [0.4, 0.0, 0.4])\n",
-    "ws_lp = np.array(ws_lp)\n",
-    "ws_lp[np.isclose(ws_lp, 0, rtol=threshold)] = 0\n",
-    "\n",
-    "ws_lp_perm, _ = lp_pmd(datasets_perm, [0.4, 0.0, 0.4])\n",
-    "ws_lp_perm = np.array(ws_lp_perm)\n",
-    "ws_lp_perm[np.isclose(ws_lp, 0, rtol=threshold)] = 0"
+    "ws_lp_perm, _ = lp_pmd(datasets_perm, [0.4, 0.0, 0.4])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([[[-6.09416697e-01],\n",
-       "        [-7.92850123e-01],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00]],\n",
-       "\n",
-       "       [[ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 8.88854528e-08],\n",
-       "        [ 0.00000000e+00]],\n",
-       "\n",
-       "       [[ 8.69830201e-01],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [-4.93351244e-01],\n",
-       "        [ 0.00000000e+00]]])"
+       "True"
       ]
      },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ws_lp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([[[-5.73418393e-18],\n",
-       "        [-1.01421456e-17],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00]],\n",
-       "\n",
-       "       [[ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 3.46602125e-11],\n",
-       "        [ 0.00000000e+00]],\n",
-       "\n",
-       "       [[ 8.62126560e-01],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [ 0.00000000e+00],\n",
-       "        [-5.06693026e-01],\n",
-       "        [ 0.00000000e+00]]])"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ws_lp_perm"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 22,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -548,88 +400,21 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### R (in python)"
+    "### Iterative Optimization"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
-    "ws_r, _ = multicca_pmd(datasets, penalties)\n",
-    "ws_r_perm, _ = multicca_pmd(datasets_perm, penalties)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[array([[ 0.        ],\n",
-       "        [ 0.90824506],\n",
-       "        [ 0.29728456],\n",
-       "        [-0.29447039],\n",
-       "        [ 0.        ]]),\n",
-       " array([[ 0.56055407],\n",
-       "        [-0.07202121],\n",
-       "        [ 0.04359745],\n",
-       "        [-0.82382725],\n",
-       "        [ 0.        ]]),\n",
-       " array([[-0.7682389 ],\n",
-       "        [-0.09935492],\n",
-       "        [-0.63240619],\n",
-       "        [ 0.        ],\n",
-       "        [-0.        ]])]"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ws_r"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[array([[-0.76824118],\n",
-       "        [-0.09935549],\n",
-       "        [-0.63240334],\n",
-       "        [ 0.        ],\n",
-       "        [-0.        ]]),\n",
-       " array([[ 0.        ],\n",
-       "        [ 0.90824509],\n",
-       "        [ 0.29727909],\n",
-       "        [-0.29447581],\n",
-       "        [ 0.        ]]),\n",
-       " array([[ 0.5605532 ],\n",
-       "        [-0.0720213 ],\n",
-       "        [ 0.04359766],\n",
-       "        [-0.82382782],\n",
-       "        [ 0.        ]])]"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ws_r_perm"
+    "ws_io, _ = multicca_pmd(datasets, penalties)\n",
+    "ws_io_perm, _ = multicca_pmd(datasets_perm, penalties)"
    ]
   },
   {
@@ -641,31 +426,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "IO sparsity: 0.4\n",
-      "LP sparsity: 0.6\n",
-      "IO sparsity: 0.19999999999999996\n",
-      "LP sparsity: 0.8\n",
-      "IO sparsity: 0.4\n",
-      "LP sparsity: 0.6\n"
-     ]
-    }
-   ],
-   "source": [
-    "for i in range(len(ws_r)):\n",
-    "    print(\"IO penalties:\", 1 - np.count_nonzero(ws_r[i]) / ws_r[i].size)\n",
-    "    print(\"LP penalties:\", 1 - np.count_nonzero(ws_lp[i]) / ws_lp[i].size)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -674,52 +435,26 @@
        "False"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test_weights(np.array(ws_r), np.array(ws_r_perm), [1,2,0])"
+    "test_weights(np.array(ws_io), np.array(ws_io_perm), [1,2,0])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Test with decimal tolerance 1."
+    "Test with decimal tolerance 2."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test_weights(np.array(ws_r), np.array(ws_r_perm), [1,2,0], dec=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Test the equivalent negative solution."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -728,13 +463,13 @@
        "False"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 53,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test_weights(np.array(ws_r), -np.array(ws_r_perm), [1,2,0], dec=1)"
+    "test_weights(np.array(ws_io), np.array(ws_io_perm), [1,2,0], dec=2)"
    ]
   },
   {

--- a/sparsecca/_multicca_lp.py
+++ b/sparsecca/_multicca_lp.py
@@ -4,28 +4,33 @@ from collections import defaultdict
 import pyomo.environ as pyo
 
 from ._utils_pmd import scale, preprocess_datasets
+from ._utils_pmd import soft
 
 
 def _ObjRule(model):
     """Objective Function (4.3 in witten 2009)"""
     features = len(model.F.data())
-    samples = len(model.S.data())
     return sum(
-                (np.asarray([model.w_i_f[idx, f] for f in model.F.data()])[np.newaxis]
-               @ np.asarray(xi).reshape(samples,features).T 
-               @ np.asarray(xj).reshape(samples,features)
-               @ np.asarray([model.w_i_f[jdx, f] for f in model.F.data()])[np.newaxis].T)[0,0] 
-               for idx, xi in enumerate(model.X) for jdx, xj in enumerate(model.X) if idx<jdx )
+        (
+            np.asarray([model.w_i_f[s, f] for f in model.F.data()])[np.newaxis]
+            @ np.asarray(model.Y[(s, t)]).reshape(features, features)
+            @ np.asarray([model.w_i_f[t, f] for f in model.F.data()])[np.newaxis].T
+        )[0, 0]
+        for s, t in model.st
+    )
 
 
-def _update_w_lp(datasets, penalties, ws_init):
+def _update_w_lp(covs, penalties, ws_init, n_datasets, n_samples, n_features):
     """Solves 4.3 of witten 2009 with linear programming approach
 
     Params
     ------
-    datasets: N matrices [samples x features]
+    covs: set of covariance matrices, Y_st = X_s.T @ X_t for s,t in [1:n], s < t
     penalties: list of length N for each Xi
     ws_init: initial values for ws, usually provided by svd
+    n_datasets: number of datasets
+    n_samples: number of samples
+    n_features: number of features
 
     Returns
     -------
@@ -33,14 +38,19 @@ def _update_w_lp(datasets, penalties, ws_init):
             - for each matrix Xn in datasets (n in [1:n]): n-> weights_vector
             - each weights_vector: list of length f (featuresize)
             - f = len(datasets[0][0])
-        """
+    """
     model = pyo.ConcreteModel()
 
-    # sets 
-    model.N = pyo.Set(initialize=range(len(datasets)))
-    model.S = pyo.Set(initialize=range(len(datasets[0])))
-    model.F = pyo.Set(initialize=range(len(datasets[0][0])))
-    model.X = pyo.Set(initialize=datasets)
+    # sets
+    model.N = pyo.Set(initialize=range(n_datasets))
+    model.S = pyo.Set(initialize=range(n_samples))
+    model.F = pyo.Set(initialize=range(n_features))
+    model.st = pyo.Set(initialize=list(covs.keys()))
+
+    def _init_Y(m, s, t):
+        return covs[(s, t)]
+
+    model.Y = pyo.Set(model.st, initialize=_init_Y)
 
     # params: ci i in [1:K]
     model.c = pyo.Param(model.N, initialize=penalties)
@@ -49,35 +59,36 @@ def _update_w_lp(datasets, penalties, ws_init):
     model.w_i_f = pyo.Var(model.N, model.F, initialize=0.5)
     for n in range(len(ws_init)):  # datasets
         for f in range(len(ws_init[0])):  # features
-            model.w_i_f[n,f].value = ws_init[n][f][0]
+            model.w_i_f[n, f].value = ws_init[n][f][0]
+
+    model.d_i_f = pyo.Var(model.N, model.F, initialize=0, domain=pyo.Binary)
 
     # obj
     model.Obj = pyo.Objective(rule=_ObjRule, sense=pyo.maximize)
-    
-    # constraints: lasso 
+
+    # constraints: lasso
     model.constraint_lasso = pyo.ConstraintList()
     for i in model.N:
-        model.constraint_lasso.add(sum(model.w_i_f[i,f] for f in model.F.data())<= model.c[i])
-        
-    # constraints: (2-norm)^2 ||wi||22 <=1
+        model.constraint_lasso.add(sum(model.w_i_f[i, f] for f in model.F.data()) <= 1.0)
+
+    # constraints: (2-norm)^2 ||wi||_2^2 <=1
     model.constraint_norm2 = pyo.ConstraintList()
     for i in model.N:
-        model.constraint_norm2.add(sum(model.w_i_f[i,f] * model.w_i_f[i,f] for f in model.F.data()) <= 1)
-        
+        model.constraint_norm2.add(sum(model.w_i_f[i, f] * model.w_i_f[i, f] for f in model.F.data()) <= 1)
+
     # solving
-    nonLinearOpt = pyo.SolverFactory('ipopt')
+    nonLinearOpt = pyo.SolverFactory("ipopt")
     instance_non_linear = model.create_instance()
     res = nonLinearOpt.solve(instance_non_linear)
     model.solutions.load_from(res)
-    
-    from collections import defaultdict
-    w = defaultdict(list)
+
+    np.zeros((n_datasets, n_features, 1))
+    w = np.zeros((n_datasets, n_features, 1))
     for i in model.N:
         for f in model.F.data():
-            w[i].append(instance_non_linear.w_i_f[i,f].value) 
-            
-    return w
+            w[i, f, 0] = instance_non_linear.w_i_f[i, f].value
 
+    return w
 
 
 def lp_pmd(datasets, penalties, K=1, standardize=True, mimic_R=True):
@@ -107,45 +118,53 @@ def lp_pmd(datasets, penalties, K=1, standardize=True, mimic_R=True):
         List of arrrays of length `K` which contain the svd initializations for `w`.
 
     """
-    sample_size = len(datasets[0])
+    n_datasets = len(datasets)
+    n_samples = len(datasets[0])
     n_features = len(datasets[0][0])
 
     # preprocessing for pyomo
-    datasets_next = preprocess_datasets(datasets, standardize=standardize, mimic_R=mimic_R)
-    datasets_next = [datasets[idx].tolist() for idx in range(len(datasets))]
+    datasets = preprocess_datasets(datasets, standardize=standardize, mimic_R=mimic_R)
+
+    # calculate covariance matrices
+    covs_next = {}
+    for i, X_i in enumerate(datasets):
+        for j, X_j in enumerate(datasets):
+            if i < j:
+                covs_next[(i, j)] = X_i.T @ X_j
+
+    covs_next = {(s, t): cov.tolist() for (s, t), cov in covs_next.items()}
 
     weights = []
     k = 0
     ws_inits = []
     for k in range(K):
         # slightly different initialization - recalculate the svd per K
-        ws_init=[]
-        for idx in range(len(datasets_next)):
-            ws_init.append(svd(datasets_next[idx])[2][0:K].T)
+        ws_init = []
+        for idx in range(len(datasets)):
+            ws_init.append(svd(datasets[idx])[2][0:K].T)
         ws_inits.append(np.array(ws_init))
-        w = _update_w_lp(datasets_next, penalties, ws_init)
-        datasets_current = datasets_next
-    
-        w_samples = {}
-        for w_n in w:
-            w_sample = np.repeat(w[w_n],sample_size, axis=0).reshape(sample_size, n_features)
-            w_samples[w_n] = w_sample
+        w = _update_w_lp(covs_next, penalties, ws_init, n_datasets, n_samples, n_features)
 
-        datasets_next = []
-        for i, X_i in enumerate(datasets_current):
-            X_i_next = X_i - w_samples[i]
-            datasets_next.append(X_i_next.tolist())
-            
-        weights.append(w)      
+        covs_current = covs_next
+        covs_next = {}
+        for (s, t), Y_st in covs_current.items():
+            Y_st = np.array(Y_st)
+            Y_st_next = Y_st - (w[s].T @ Y_st @ w[t]) * (w[s] @ w[t].T)
+            covs_next[(s, t)] = Y_st_next.tolist()
+
+        weights.append(w)
 
     w_final = np.zeros((len(datasets), n_features, K))
     for k, w_k in enumerate(weights):
-        for n, w_value in enumerate(w_k.values()):
+        for n, w_value in enumerate(w_k):
             for f, w_feature in enumerate(w_value):
                 w_final[n][f][k] = w_feature
 
-    ws_init = [v.reshape(K, n_features).T for v in np.concatenate(  # could probably be simpler
-        [x[:, :, 0].reshape(len(datasets), n_features) for x in ws_inits], axis=1)]
+    ws_init = [
+        v.reshape(K, n_features).T
+        for v in np.concatenate(  # could probably be simpler
+            [x[:, :, 0].reshape(len(datasets), n_features) for x in ws_inits], axis=1
+        )
+    ]
 
     return list(w_final), ws_init
-    


### PR DESCRIPTION
This was due to incorrect substraction of previous CCAs from the inputs for the next iteration. The LP implementation had to be changed to fit to _"Algorithm for obtaining J sparse mCCA factors", Appendix B, [Extensions of Sparse Canonical Correlation Analysis with Applications to Genomic Data, Witten et al. 2009](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2861323/)_.
This change seems to also have slightly affected the resulting for the first CCA. I believe they shouldn't have been changed by this, since the objective function is mathematically equivalent. But I guess it might not be numerically equivalent leading the LP solver to arrive at a slightly different solution.